### PR TITLE
allow HTTP version at the end of an HTTP 0.9 request line

### DIFF
--- a/interop/http09/server.go
+++ b/interop/http09/server.go
@@ -126,9 +126,9 @@ func (s *Server) handleStream(str quic.Stream) error {
         }
         log.Printf("split[0]=%s", split[0])
         u, err := url.Parse(split[0])
-	if err != nil {
-		return err
-	}
+        if err != nil {
+                return err
+        }
 	u.Scheme = "https"
 
 	req := &http.Request{

--- a/interop/http09/server.go
+++ b/interop/http09/server.go
@@ -119,7 +119,7 @@ func (s *Server) handleStream(str quic.Stream) error {
 	}
 
 	split := strings.Split(request[4:], " ")
-	if len(split) > 2  || (len(split) == 2 && split[1] != "HTTP/0.9"){
+	if len(split) > 2  || (len(split) == 2 && split[1] != "HTTP/0.9") {
 		return nil
 	}
 	u, err := url.Parse(split[0])

--- a/interop/http09/server.go
+++ b/interop/http09/server.go
@@ -118,7 +118,14 @@ func (s *Server) handleStream(str quic.Stream) error {
 		return nil
 	}
 
-	u, err := url.Parse(request[4:])
+	split := strings.Split(request[4:], " ")
+        log.Printf("len(split)=%d", len(split))
+
+        if len(split) > 2  || (len(split) == 2 && split[1] != "HTTP/0.9"){
+                return nil
+        }
+        log.Printf("split[0]=%s", split[0])
+        u, err := url.Parse(split[0])
 	if err != nil {
 		return err
 	}

--- a/interop/http09/server.go
+++ b/interop/http09/server.go
@@ -119,16 +119,13 @@ func (s *Server) handleStream(str quic.Stream) error {
 	}
 
 	split := strings.Split(request[4:], " ")
-        log.Printf("len(split)=%d", len(split))
-
-        if len(split) > 2  || (len(split) == 2 && split[1] != "HTTP/0.9"){
-                return nil
-        }
-        log.Printf("split[0]=%s", split[0])
-        u, err := url.Parse(split[0])
-        if err != nil {
-                return err
-        }
+	if len(split) > 2  || (len(split) == 2 && split[1] != "HTTP/0.9"){
+		return nil
+	}
+	u, err := url.Parse(split[0])
+	if err != nil {
+		return err
+	}
 	u.Scheme = "https"
 
 	req := &http.Request{


### PR DESCRIPTION
it is a bit of a gray area, but  we believe a fully compliant server should accept 0.9 as a version. 

According to https://www.w3.org/Protocols/HTTP/Request.html 
> If the protocol version is not specified, the server assumes that the browser uses HTTP version 0.9
this sets 0.9 to the default, but doesn't say that it should not be set. 

From https://tools.ietf.org/html/rfc1945#section-5.1 also 
> This document defines both the 0.9 and 1.0 versions of the HTTP protocol.
and 
> The Request-Line begins with a method token, followed by the
>   Request-URI and the protocol version, and ending with CRLF. The
>   elements are separated by SP characters. No CR or LF are allowed
>   except in the final CRLF sequence.
>
>       Request-Line = Method SP Request-URI SP HTTP-Version CRLF